### PR TITLE
fix: move Older versions label above broken SHAs

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -23,6 +23,7 @@ versions:
       Payload aligned with Inspector SDK v2 format (libVersion 2.0.0, ISO 8601 timestamps, streamId, samplingRate).
       Filters out internal x-sst- and x-ga- prefixed properties from the event schema.
       Encryption not supported: GTM Server sandbox does not provide cryptographic APIs; encryptedPropertyValue is always null.
+  # Older versions
   - sha: 6cd894ddb96df3d005fb6157c14edf80e03f86eb
     changeNotes: |2
       Bump template version to 2 and update description to reflect anonymous ID resolution and dev/staging validation.
@@ -32,7 +33,6 @@ versions:
       Local value validation (dev/staging only): fetches the tracking plan spec from the Avo API and validates event properties against type, required, pinned value, allowed value, and min/max range constraints.
       Encryption not supported: GTM Server sandbox does not provide cryptographic APIs; encryptedPropertyValue is always null.
       Filters out internal x-sst- and x-ga- prefixed properties from the event schema.
-  # Older versions
   - sha: 72047fbf349edc260e8e467e774725448905cdc5
     changeNotes: |2
       Upping timeout to 2000ms.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -15,7 +15,7 @@
 homepage: "https://www.avo.app"
 documentation: "https://www.avo.app/docs/data-design/start-using-inspector"
 versions:
-  #Latest version
+  # Latest version
   - sha: 2daee5e8434778bc2faab40029fdb7e71dac7dfe
     changeNotes: |2
       Anonymous ID / Stream ID: resolves anonymousId from event data (client_id → x-ga-js_client_id) and sends it as streamId. user_id is intentionally excluded to preserve anonymity.
@@ -37,7 +37,6 @@ versions:
     changeNotes: |2
       Upping timeout to 2000ms.
       Adding catch to return to GTM failure if request fails.
-  # Even older versions
   - sha: 8eeb5fa46615775425cd02c8f802b0a11c5c0391
     changeNotes: Removed logs
   - sha: 311f03d8cdd61748e017647bb752352fbaed49b3


### PR DESCRIPTION
## Summary
- Move `# Older versions` comment to correctly group all non-latest SHAs (including the two broken ones)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Minor formatting updates to internal metadata files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->