### PR TITLE
release: set SHA for list-of-objects schema fix

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,7 +16,7 @@ homepage: "https://www.avo.app"
 documentation: "https://www.avo.app/docs/data-design/start-using-inspector"
 versions:
   # Latest version
-  - sha: 0000000000000000000000000000000000000000  # set to the release commit SHA at publish time
+  - sha: e93efa7800f0dd4b636ded1ddfa3f738fc7bf677
     changeNotes: |2
       Fix: capture the structure of objects nested inside lists (list-of-objects) in the event schema. Array properties are now introspected element-by-element and deduplicated — children was previously always null — matching the Avo Inspector SDK's schema output.
   # Older versions


### PR DESCRIPTION
Sets the version `sha` in `metadata.yaml` to the PR #14 merge commit `e93efa7800f0dd4b636ded1ddfa3f738fc7bf677`, replacing the publish-time placeholder (`0000…`).

This is the standard post-merge release step (see `0a6e85b`, `321fc57`): a commit can't reference its own SHA, so the new version entry points at the merge commit that actually contains the fixed `template.tpl`. Once this lands on `master`, the GTM Community Template Gallery reads `metadata.yaml` from the branch tip, sees the new version, and fetches `template.tpl` at that SHA.

Verified: `template.tpl` at `e93efa7` contains the list-of-objects fix (array branch + `removeDuplicates`).

No branch protection on `master`, so this can be merged without a second approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the latest version reference to point to the newest release commit.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->