### PR TITLE
release: publish sha for configurable common fields (2.1.0)

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,15 +16,13 @@ homepage: "https://www.avo.app"
 documentation: "https://www.avo.app/docs/data-design/start-using-inspector"
 versions:
   # Latest version
-  # NOTE: placeholder sha — replace with the real merge commit sha after this PR merges.
-  - sha: 0000000000000000000000000000000000000000
+  - sha: c51e468f0b32e1c914f22eb0ed2f51c87afa46b6
     changeNotes: |2
       Feature: configurable common-field exclusions. New "Common fields to include in Inspector schemas" tag parameter opts default-excluded fields (e.g. user_id, currency) back into the Inspector event schema. Defaults unchanged when the table is empty; only property names and types are ever sent. libVersion 2.1.0.
   # Older versions
   - sha: e93efa7800f0dd4b636ded1ddfa3f738fc7bf677
     changeNotes: |2
       Fix: capture the structure of objects nested inside lists (list-of-objects) in the event schema. Array properties are now introspected element-by-element and deduplicated — children was previously always null — matching the Avo Inspector SDK's schema output.
-  # Older versions
   - sha: 2daee5e8434778bc2faab40029fdb7e71dac7dfe
     changeNotes: |2
       Anonymous ID / Stream ID: resolves anonymousId from event data (client_id → x-ga-js_client_id) and sends it as streamId. user_id is intentionally excluded to preserve anonymity.


### PR DESCRIPTION
Post-merge release step for #16: sets the latest `metadata.yaml` version entry to the real merge commit sha (`c51e468f0b32e1c914f22eb0ed2f51c87afa46b6`) so the Community Template Gallery can pick up the new version, and drops the duplicate `# Older versions` comment flagged in review.

`template.tpl` at `c51e468` is the released content (libVersion 2.1.0, 17/17 editor tests confirmed on the PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release/version metadata so the feature history now points to the correct published revision.
  * Kept the existing change notes intact, with prior version information preserved in order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->