### PR TITLE
release: repoint 2.1.0 sha to include thumbnail fix

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,9 +16,10 @@ homepage: "https://www.avo.app"
 documentation: "https://www.avo.app/docs/data-design/start-using-inspector"
 versions:
   # Latest version
-  - sha: c51e468f0b32e1c914f22eb0ed2f51c87afa46b6
+  - sha: b9e4fbfb955e65a1145698e4ce351a759d3111af
     changeNotes: |2
       Feature: configurable common-field exclusions. New "Common fields to include in Inspector schemas" tag parameter opts default-excluded fields (e.g. user_id, currency) back into the Inspector event schema. Defaults unchanged when the table is empty; only property names and types are ever sent. libVersion 2.1.0.
+      Fixed the brand thumbnail (previous embedded image was corrupted).
   # Older versions
   - sha: e93efa7800f0dd4b636ded1ddfa3f738fc7bf677
     changeNotes: |2


### PR DESCRIPTION
Moves the (not yet crawled) 2.1.0 gallery version entry from `c51e468f` to `b9e4fbfb` — the #18 merge commit — so the gallery publishes the configurable-common-fields feature and the fixed brand thumbnail as a single version. Adds a changeNotes line for the thumbnail.

Verified: `b9e4fbfb` is on master; `template.tpl` at that sha has libVersion 2.1.0 and the new logomark.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the latest release notes entry to reflect the newest build.
  * Added a note about a fix for a corrupted brand thumbnail.
  * Kept the existing note about configurable common-field exclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->